### PR TITLE
Do not inject authorization_details into token responses when not requested

### DIFF
--- a/internal/gateway/rest/rest.go
+++ b/internal/gateway/rest/rest.go
@@ -183,13 +183,12 @@ func (a API) GetTokenHandler(c *fiber.Ctx) error {
 		configuration = &storedAuth.CredentialConfigurations[index]
 
 	} else {
+		// Wallet did not send authorization_details in the token request (normal
+		// for the pre-authorized code grant — the wallet uses credential_configuration_ids
+		// from the offer instead). Do not inject authorization_details into the
+		// response; sending it unsolicited (potentially with an empty identifier
+		// list) causes wallets to reject the response or fail on it.
 		if len(storedAuth.CredentialConfigurations) == 1 {
-			tokenResp.AuthorizationDetails = &oauth.AuthorizationDetails{
-				Type:                      "openid_credential",
-				CredentialConfigurationID: storedAuth.CredentialConfigurations[0].Id,
-				CredentialIdentifiers:     storedAuth.CredentialConfigurations[0].CredentialIdentifier,
-				Claims:                    storedAuth.Claims,
-			}
 			configuration = &storedAuth.CredentialConfigurations[0]
 		}
 


### PR DESCRIPTION
In the pre-authorized code grant flow, wallets do not send `authorization_details` in the token request. The bridge nevertheless injects it into the token response whenever the stored authorization has exactly one credential configuration — carrying the stored `credential_identifier` list verbatim, which is empty for offers created by the OCM-W issuer service.

Downstream this breaks credential retrieval: eclipse-xfsc/oid4-vci-credential-retrieval-service indexes into `credential_identifiers` whenever `authorization_details` is present and panics with `index out of range [0] with length 0` (guard proposed in eclipse-xfsc/oid4-vci-credential-retrieval-service#11), and spec-conformant external wallets reject the unsolicited field.

This change only populates `authorization_details` in the response when the client included it in the request. Verified against a full smartdeployment-provisioned OCM-W stack: with this and the linked retrieval fix, offer → token → credential completes end to end.

Note: `authorization_details` in token responses should also be a JSON array per RFC 9396 §7.1 — it is currently serialized as a single object (the type comes from `oid4-vci-vp-library`). That is a coordinated change across the library and its consumers, so it is intentionally not part of this PR.